### PR TITLE
Support multiple branch backup

### DIFF
--- a/bbbackup_sample.cfg
+++ b/bbbackup_sample.cfg
@@ -11,7 +11,7 @@ app_name = <value here>
 [bitbucket_account]
 ; enter your credentials for bitbucket here, use same for user and team if you want user
 userid = <value here>
-password = 
+password =
 teamname = <value here>
 
 [slack]
@@ -26,9 +26,9 @@ max_retries = 3
 max_fails = 1
 min_free_space = 50
 amount_of_days_to_store = 7
+all_branches = true
 
 [log]
 ; enter log related options as true and false
 logging_on = True
 colorized_logging_on = True
-


### PR DESCRIPTION
add `backup.all_branches` option to provide ability to clone all branches of a repo - this actually allows us to save code which may currently be a work in progress. It's also the most likely code to be accidentally deleted.

Set `all_branches = true` under the `[backup]` section to enable the feature.

I didn't add options for enabling this via CLI. This is at least a start!