### PR TITLE
using repo slug instead of repo name for git clone

### DIFF
--- a/bbbackup.py
+++ b/bbbackup.py
@@ -1237,7 +1237,7 @@ def bitbucket_clone( repos ):
                 num_of_tries +=1
                 mark_repo_sync( BACKUP_LOCAL_REPO_PATH )
                 try:
-                    REMOTE_REPO_PATH = 'git@bitbucket.org:{}/{}.git'.format( CONFIG_TEAM, repo_name)
+                    REMOTE_REPO_PATH = 'git@bitbucket.org:{}/{}.git'.format( CONFIG_TEAM, repo['slug'])
                     Repo.clone_from( REMOTE_REPO_PATH, BACKUP_LOCAL_REPO_PATH )
                     was_cloning_fail = False
                     success_clone = success_clone + 1


### PR DESCRIPTION
This fixes issues where the repo name has spaces or other concerning characters

Addresses issue #4 