### PR TITLE
Issue #10 - fix for uncommon repository names

### DIFF
--- a/bbbackup.py
+++ b/bbbackup.py
@@ -1120,6 +1120,21 @@ FROM API 1.0 WE GET
 }
 '''
 
+def repo_fix( repo_name ):
+    if " " in repo_name:
+        repo_name = repo_name.replace(' & ', '-')
+        repo_name = repo_name.replace(' - ','-')
+        repo_name = repo_name.replace(' ', '-').lower()
+
+    repo_name = repo_name.replace(']', '').lower()
+    repo_name = repo_name.replace('[', '')
+    repo_name = repo_name.replace('/', '-')
+    repo_name = repo_name.replace('(', '-')
+    repo_name = repo_name.replace(')', '')
+    repo_name = repo_name.replace('#', '')
+    return repo_name
+
+
 # ANALYZE EXISTING LOCAL REPOSITORIES COMPARED TO REMOTE REPOSITORIES (SAME DAY)
 def bitbucket_analyze( repos ):
     counted = 0
@@ -1157,6 +1172,7 @@ def bitbucket_analyze( repos ):
 
     for repo in repos:
         repo_slug = repo['slug']
+        repo_slug = repo_fix(repo_slug)
         BACKUP_LOCAL_REPO_PATH = os.path.abspath( os.path.join( BACKUP_LOCAL_PATH, repo_slug ) )
 
         if os.path.exists( BACKUP_LOCAL_REPO_PATH ) and repo_status_is( BACKUP_LOCAL_REPO_PATH, STATUS_DONE ):
@@ -1218,6 +1234,7 @@ def bitbucket_clone( repos ):
 
     for repo in repos:
         repo_slug = repo['slug']
+        repo_slug = repo_fix(repo_slug)
         BACKUP_LOCAL_REPO_PATH = os.path.abspath( os.path.join( BACKUP_LOCAL_PATH, repo_slug ) )
 
         # STEP 1: check if repo marked as SYNC/FAIL


### PR DESCRIPTION
Let's give this a second try as it seems I failed massively the first time around 🤦 

As discussed in issue #10 , I've found that bitbucket repo names can include a ton of different uncommon chars.

So I've created a method that cleans it up and standardises them so the script doesn't fail.

Happy to discuss the options I've made for the replacement chars.