### PR TITLE
Fixing total size function to not fail with broken symlinks

### DIFF
--- a/bbbackup.py
+++ b/bbbackup.py
@@ -271,7 +271,8 @@ def get_size( dir_path ):
     for dirpath, dirnames, filenames in os.walk( dir_path ):
         for f in filenames:
             fp = os.path.join(dirpath, f)
-            total_size += os.path.getsize(fp)
+            if os.path.isfile(fp):
+              total_size += os.path.getsize(fp)
     return total_size
 
 # HELPER TO COLORIZE PRINT OUTPUT


### PR DESCRIPTION
If there is a broken symlink in a repo the file size calculation will break. This fix checks to make sure it is a file before adding it to the calculation.